### PR TITLE
added model

### DIFF
--- a/meme.smv
+++ b/meme.smv
@@ -1,0 +1,62 @@
+MODULE main
+
+VAR
+    --MEMEからの送信データ--
+    --{空, MEME正常, MEME異常, b, c} --
+    DATA : {emp, dt_a_T, dt_a_F, dt_b, dt_c};
+
+    --サーバのメモリ--
+    --{空, a, ab, ac, 全蓄積} --
+    MEM : {emp, dt_a, dt_ab, dt_ac, full};
+
+    --印刷ボタン（TRUE:表示FALSE:非表示）--
+    BTN : boolean;
+
+    --係員の印刷ボタン押下（TRUE:押すFALSE:押さない）--
+    STAFF : boolean;
+
+    --印刷内容--
+    PRT : {emp, dt_a, dt_ab, dt_ac, full};
+
+ASSIGN
+    -- 初期値の設定 --
+    init(DATA) := emp;
+    init(MEM) := emp;
+    init(BTN) := FALSE;
+    init(STAFF) :=  FALSE;
+    init(PRT) := emp;
+
+    -- 状態遷移の記述 --
+    next(DATA) := {emp, dt_a_T, dt_a_F, dt_b, dt_c};
+
+    next(MEM) := case
+        MEM = emp & DATA = dt_a_T : dt_a;
+        MEM = dt_a & DATA = dt_b : dt_ab;
+        MEM = dt_a & DATA = dt_c : dt_ac;
+        MEM = dt_ab & DATA = dt_c : full;
+        MEM = dt_ab & DATA = dt_a_F : emp;
+        MEM = dt_ac & DATA = dt_b : full;
+        MEM = dt_ac & DATA = dt_a_F : emp;
+        MEM = full & STAFF = TRUE : emp;
+        MEM = full  & DATA = dt_a_F : emp;
+        TRUE : MEM;
+    esac;
+
+    next(BTN) := case
+        BTN = FALSE & MEM = full : TRUE;
+        BTN = TRUE & STAFF = TRUE : FALSE;
+        TRUE : BTN;
+    esac;
+
+    next(STAFF) := case
+        STAFF = FALSE & BTN = TRUE : TRUE;
+        STAFF = TRUE & BTN = FALSE : FALSE;
+        TRUE : STAFF;
+    esac;
+
+    next(PRT) := case
+        BTN = TRUE & STAFF = TRUE : MEM;
+        TRUE : emp;
+    esac;
+
+SPEC !EF(PRT = dt_a)

--- a/result
+++ b/result
@@ -1,0 +1,48 @@
+*** This is NuSMV 2.6.0 (compiled on Wed Oct 14 15:36:56 2015)
+*** Enabled addons are: compass
+*** For more information on NuSMV see <http://nusmv.fbk.eu>
+*** or email to <nusmv-users@list.fbk.eu>.
+*** Please report bugs to <Please report bugs to <nusmv-users@fbk.eu>>
+
+*** Copyright (c) 2010-2014, Fondazione Bruno Kessler
+
+*** This version of NuSMV is linked to the CUDD library version 2.4.1
+*** Copyright (c) 1995-2004, Regents of the University of Colorado
+
+*** This version of NuSMV is linked to the MiniSat SAT solver. 
+*** See http://minisat.se/MiniSat.html
+*** Copyright (c) 2003-2006, Niklas Een, Niklas Sorensson
+*** Copyright (c) 2007-2010, Niklas Sorensson
+
+-- specification !(EF PRT = dt_a)  is false
+-- as demonstrated by the following execution sequence
+Trace Description: CTL Counterexample 
+Trace Type: Counterexample 
+  -> State: 1.1 <-
+    DATA = emp
+    MEM = emp
+    BTN = FALSE
+    STAFF = FALSE
+    PRT = emp
+  -> State: 1.2 <-
+    DATA = dt_a_T
+  -> State: 1.3 <-
+    DATA = dt_c
+    MEM = dt_a
+  -> State: 1.4 <-
+    DATA = dt_b
+    MEM = dt_ac
+  -> State: 1.5 <-
+    DATA = dt_a_F
+    MEM = full
+  -> State: 1.6 <-
+    DATA = dt_a_T
+    MEM = emp
+    BTN = TRUE
+  -> State: 1.7 <-
+    MEM = dt_a
+    STAFF = TRUE
+  -> State: 1.8 <-
+    DATA = emp
+    BTN = FALSE
+    PRT = dt_a


### PR DESCRIPTION
[Nusmv の実行バイナリ](https://nusmv.fbk.eu/)をダウンロードの上、プロジェクトディレクトリで
下記のようにコマンドを実行することで結果を出力する。
```
NuSMV-2.6.0-Linux/bin/NuSMV meme.smv > result
```
反例結果より、 mem= full の状態になるとBTN=TRUEとなり印刷可能状態となる。
この状態から、MEMEの異常値が送信されると mem がパージされて空に戻る。
ここから MEMEの正常値が蓄積されたあとにSTAFFがボタンを押下することで、 MEME(a)の状態のみでプリントされてしまう。

